### PR TITLE
Log token usage

### DIFF
--- a/src/e84_geoai_common/llm/models/claude.py
+++ b/src/e84_geoai_common/llm/models/claude.py
@@ -274,6 +274,8 @@ class BedrockClaudeLLM(LLM):
             log.exception("Request body: %s", request.model_dump_json())
             raise
         response_body = response["body"].read().decode("UTF-8")
-        return ClaudeResponse.model_validate_json(response_body)
+        claude_response = ClaudeResponse.model_validate_json(response_body)
+        log.info("Token usage: %s", claude_response.usage)
+        return claude_response
 
     # FUTURE implement tool use

--- a/src/e84_geoai_common/llm/models/nova.py
+++ b/src/e84_geoai_common/llm/models/nova.py
@@ -240,7 +240,9 @@ class BedrockNovaLLM(LLM):
             log.exception("Request body: %s", request.model_dump_json())
             raise
         response_body = response["body"].read().decode("UTF-8")
-        return NovaResponse.model_validate_json(response_body)
+        nova_response = NovaResponse.model_validate_json(response_body)
+        log.info("Token usage: %s", nova_response.usage)
+        return nova_response
 
 
 #########################


### PR DESCRIPTION
Log the token usage info returned by Bedrock.

Tested with:

```sh
pytest --log-cli-level=INFO
```
Output excerpt:
```
tests/llm/models/test_claude.py::test_json_mode 
---------------------------------------------------- live log call -----------------------------------------------------
INFO     e84_geoai_common.llm.models.claude:claude.py:278 Token usage: input_tokens=123 output_tokens=321
INFO     e84_geoai_common.util:util.py:91 invoke_model_with_request took 0.000123 seconds to run.
INFO     e84_geoai_common.util:util.py:91 prompt took 0.000184 seconds to run.
PASSED                                                                                                           [ 33%]
tests/llm/models/test_nova.py::test_basic_usage 
---------------------------------------------------- live log call -----------------------------------------------------
INFO     e84_geoai_common.llm.models.nova:nova.py:244 Token usage: input_tokens=123 output_tokens=123 total_tokens=123 cache_read_input_token_count=123 cache_write_input_token_count=123
INFO     e84_geoai_common.util:util.py:91 invoke_model_with_request took 0.000176 seconds to run.
INFO     e84_geoai_common.util:util.py:91 prompt took 0.000244 seconds to run.
PASSED                                                                                                           [ 44%]
```