### PR TITLE
Add an `execute()` method to `LLMTool`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "types-shapely>=2.0.0.20240820",
   "function_schema>=0.4.4",
   "rich",
+  "mypy-boto3-bedrock-runtime>=1.37.0",
 ]
 dynamic = ["version"]
 

--- a/tests/llm/models/test_claude.py
+++ b/tests/llm/models/test_claude.py
@@ -112,11 +112,19 @@ def test_tool_use_json() -> None:
         temperature: float = Field(description="Temperature in Celsius")
         humidity: float = Field(description="Humidity %.")
 
+    def exec_weather_tool(tool_use_request: LLMToolUseContent) -> LLMToolResultContent:
+        weather_info = WeatherInfo(weather_description="Sunny", temperature=20, humidity=50)
+        tool_result = LLMToolResultContent(
+            id=tool_use_request.id, content=[JSONContent(data=weather_info.model_dump())]
+        )
+        return tool_result
+
     tool = LLMTool(
         name="GetWeatherInfo",
         description="Get current weather info for a place.",
         input_model=GetWeatherInfoInput,
         output_model=WeatherInfo,
+        execution_func=exec_weather_tool,
     )
 
     dummy_responses = [
@@ -159,11 +167,8 @@ def test_tool_use_json() -> None:
     assert "philadelphia" in tool_inputs.place.lower()
 
     # test tool result
-    tool_result = WeatherInfo(weather_description="Sunny", temperature=20, humidity=50)
-    tool_result_content = LLMToolResultContent(
-        id=tool_use_req.id, content=[JSONContent(data=tool_result.model_dump())]
-    )
-    messages = [*messages, resp, LLMMessage(content=[tool_result_content])]
+    tool_result = tool.execute(tool_use_req)
+    messages = [*messages, resp, LLMMessage(content=[tool_result])]
     resp = llm.prompt(messages=messages, inference_cfg=config)
 
     # print out solution if doing a live test, so we can inspect it if the test fails
@@ -180,11 +185,19 @@ def test_tool_use_image() -> None:
     class ImageGeneratorInput(BaseModel):
         description: str = Field(description="Description of the image to generate.")
 
+    def exec_image_gen_tool(tool_use_request: LLMToolUseContent) -> LLMToolResultContent:
+        image_path = str(Path(__file__).parent / "images/cat.webp")
+        base64_string = encode_image_to_base64_str(image_path)
+        image_content = Base64ImageContent(media_type="image/webp", data=base64_string)
+        tool_result = LLMToolResultContent(id=tool_use_request.id, content=[image_content])
+        return tool_result
+
     tool = LLMTool(
         name="GenerateImage",
         description="Generate an image from text. Returns the generated image only.",
         input_model=ImageGeneratorInput,
         output_model=None,
+        execution_func=exec_image_gen_tool,
     )
 
     dummy_responses = [
@@ -226,12 +239,8 @@ def test_tool_use_image() -> None:
     _ = ImageGeneratorInput.model_validate(tool_use_req.input)
 
     # test tool result
-    image_path = str(Path(__file__).parent / "images/cat.webp")
-    base64_string = encode_image_to_base64_str(image_path)
-    image_content = Base64ImageContent(media_type="image/webp", data=base64_string)
-
-    tool_result_content = LLMToolResultContent(id=tool_use_req.id, content=[image_content])
-    messages = [*messages, resp, LLMMessage(content=[tool_result_content])]
+    tool_result = tool.execute(tool_use_req)
+    messages = [*messages, resp, LLMMessage(content=[tool_result])]
     resp = llm.prompt(messages=messages, inference_cfg=config)
 
     # print out solution if doing a live test, so we can inspect it if the test fails

--- a/tests/llm/models/test_claude.py
+++ b/tests/llm/models/test_claude.py
@@ -137,7 +137,6 @@ def test_tool_use_json() -> None:
             [
                 {"text": "It's always sunny in Philadelphia."},
             ],
-            overrides={"stop_reason": "tool_use"},
         ),
     ]
     client = make_test_bedrock_client(dummy_responses)
@@ -206,7 +205,6 @@ def test_tool_use_image() -> None:
             [
                 {"text": "The image contains a cat."},
             ],
-            overrides={"stop_reason": "tool_use"},
         ),
     ]
     client = make_test_bedrock_client(dummy_responses)

--- a/tests/llm/models/test_converse.py
+++ b/tests/llm/models/test_converse.py
@@ -145,7 +145,6 @@ def test_tool_use_json() -> None:
             [
                 {"text": "It's always sunny in Philadelphia."},
             ],
-            overrides={"stopReason": "tool_use"},
         ),
     ]
     client = make_test_bedrock_client(dummy_responses)
@@ -216,7 +215,6 @@ def test_tool_use_image() -> None:
             [
                 {"text": "The image contains a cat."},
             ],
-            overrides={"stopReason": "tool_use"},
         ),
     ]
     client = make_test_bedrock_client(dummy_responses)


### PR DESCRIPTION
Follow up to #19 that adds a way to associate the implementation of a tool with its definition.