### PR TITLE
Make JSON mode in Claude models more robust

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -15,7 +15,7 @@
 
 set -e -o pipefail
 
-USE_REAL_BEDROCK_CLIENT=false
+USE_REAL_BEDROCK_RUNTIME_CLIENT=false
 WATCH_MODE=false
 
 EXTRA_ARGS=()
@@ -23,7 +23,7 @@ EXTRA_ARGS=()
 for arg in "$@"; do
   case $arg in
     --use-real-bedrock-client)
-      USE_REAL_BEDROCK_CLIENT=true
+      USE_REAL_BEDROCK_RUNTIME_CLIENT=true
       shift
       ;;
     --watch)
@@ -35,7 +35,7 @@ for arg in "$@"; do
   esac
 done
 
-export USE_REAL_BEDROCK_CLIENT
+export USE_REAL_BEDROCK_RUNTIME_CLIENT
 export PYTHONPATH=src:tests
 
 if [[ "$WATCH_MODE" = true ]]; then


### PR DESCRIPTION
**Problem:** Previously, we enforced JSON mode in Claude models by setting `"{"` as the response prefix. This ensured that the LLM generated JSON but it did not ensure that it stopped generating once the JSON ended, so it would sometimes output extra text _after_ the JSON which broke the JSON parsing.

**Solution:** Change the response prefix to `"<json>\n{"` and set `"</json>"` as a stop sequence.

API docs for `stop_sequences`: https://docs.anthropic.com/en/api/messages#body-stop-sequences