### PR TITLE
Make JSON mode consistent across models

### DIFF
--- a/src/e84_geoai_common/llm/models/claude.py
+++ b/src/e84_geoai_common/llm/models/claude.py
@@ -329,14 +329,6 @@ def _llm_tool_result_to_claude_tool_result(
     return out
 
 
-def _config_to_response_prefix(config: LLMInferenceConfig) -> str | None:
-    if config.json_mode:
-        return "<json>\n{"
-    if config.response_prefix:
-        return config.response_prefix
-    return None
-
-
 class BedrockClaudeLLM(LLM):
     """Implements the LLM class for Bedrock Claude."""
 
@@ -359,18 +351,14 @@ class BedrockClaudeLLM(LLM):
     def create_request(
         self, messages: Sequence[LLMMessage], config: LLMInferenceConfig
     ) -> ClaudeInvokeLLMRequest:
-        response_prefix = _config_to_response_prefix(config)
-        if response_prefix:
-            messages = [*messages, LLMMessage(role="assistant", content=response_prefix)]
-
-        # json_mode=True sets response prefix to: "<json>\n{", by setting
-        # </json> as a step sequence, we ensure that the generation stops as
-        # soon as the JSON ends. This solves the problem of the LLM outputting
-        # additional text after the JSON which breaks the JSON parsing.
-        # Note that stop sequences are not included in the LLM response, so we
-        # don't need any post-processing to remove this closing tag from the
-        # text.
-        stop_sequences = ["</json>"] if config.json_mode else None
+        stop_sequences = None
+        if config.json_mode:
+            # https://docs.aws.amazon.com/nova/latest/userguide/prompting-structured-output.html
+            prefix = "```json\n{"
+            messages = [*messages, LLMMessage(role="assistant", content=prefix)]
+            stop_sequences = ["```"]
+        elif config.response_prefix:
+            messages = [*messages, LLMMessage(role="assistant", content=config.response_prefix)]
 
         tools = None
         tool_choice = None
@@ -430,7 +418,7 @@ class BedrockClaudeLLM(LLM):
                     text = c.text
                     if index == 0:
                         if inference_cfg.json_mode:
-                            text = "{" + text
+                            text = "{" + text.removesuffix("```")
                         elif inference_cfg.response_prefix:
                             text = inference_cfg.response_prefix + text
                     return TextContent(text=text)

--- a/src/e84_geoai_common/llm/models/nova.py
+++ b/src/e84_geoai_common/llm/models/nova.py
@@ -229,7 +229,7 @@ class BedrockNovaLLM(LLM):
         stop_sequences = None
         if config.json_mode:
             # https://docs.aws.amazon.com/nova/latest/userguide/prompting-structured-output.html
-            prefix = "```json"
+            prefix = "```json\n{"
             messages = [*messages, LLMMessage(role="assistant", content=prefix)]
             stop_sequences = ["```"]
         elif config.response_prefix:
@@ -298,10 +298,9 @@ class BedrockNovaLLM(LLM):
         if len(response_msg.content) == 1 and isinstance(response_msg.content[0], NovaTextContent):
             content = response_msg.content[0].text
             if inference_cfg.json_mode:
-                # In JSON mode we need to remove the JSON stop sequence
-                content = content.removesuffix("```")
+                content = [TextContent(text="{" + content.removesuffix("```"))]
             elif inference_cfg.response_prefix:
-                content = inference_cfg.response_prefix + content
+                content = [TextContent(text=inference_cfg.response_prefix + content)]
         else:
             content = [_to_llm_content(index, c) for index, c in enumerate(response_msg.content)]
 

--- a/tests/llm/core/test_llm.py
+++ b/tests/llm/core/test_llm.py
@@ -1,0 +1,25 @@
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+from pydantic import ValidationError
+
+from e84_geoai_common.llm.core.llm import LLMInferenceConfig, LLMTool
+
+
+class TestLLMInferenceConfig:
+    def test_json_mode_validation(self):
+        with does_not_raise():
+            _ = LLMInferenceConfig(json_mode=True, tools=None)
+
+        with does_not_raise():
+            _ = LLMInferenceConfig(json_mode=True, tools=[])
+
+        tool = LLMTool(
+            name="SomeTool",
+            description="",
+            input_model=None,
+            output_model=None,
+            execution_func=None,
+        )
+        with pytest.raises(ValidationError):
+            _ = LLMInferenceConfig(json_mode=True, tools=[tool])

--- a/tests/llm/models/test_claude.py
+++ b/tests/llm/models/test_claude.py
@@ -62,7 +62,7 @@ def test_json_mode() -> None:
     """)
     llm = BedrockClaudeLLM(
         client=make_test_bedrock_runtime_client(
-            [claude_response_with_content('"result": [1, 2, 3, 4, 5]}')]
+            [claude_response_with_content('"result": [1, 2, 3, 4, 5]}\n')]
         )
     )
     config = LLMInferenceConfig(json_mode=True)

--- a/tests/llm/models/test_nova.py
+++ b/tests/llm/models/test_nova.py
@@ -1,5 +1,8 @@
 import base64
+import json
+from contextlib import nullcontext as does_not_raise
 from pathlib import Path
+from textwrap import dedent
 
 from e84_geoai_common.llm.core.llm import (
     Base64ImageContent,
@@ -39,21 +42,57 @@ def test_with_response_prefix() -> None:
     resp = llm.prompt(
         [LLMMessage(content="Output the sum of 5 and 10 without additional explanation")], config
     )
-    assert resp == LLMMessage(role="assistant", content="5 + 10 = 15")
+    assert resp == LLMMessage(role="assistant", content=[TextContent(text="5 + 10 = 15")])
 
 
 def test_json_mode() -> None:
-    json_mode_prompt = """
+    json_mode_prompt = dedent("""
         Create a list of the numbers 1 through 5.
-    """
+
+        Here's an example of the desired output for the number 2 through 6
+        {"result": [2, 3, 4, 5, 6]}
+    """)
     llm = BedrockNovaLLM(
         client=make_test_bedrock_runtime_client(
-            [nova_response_with_content("[1, 2, 3, 4, 5]\n```")]
+            [nova_response_with_content('"result": [1, 2, 3, 4, 5]}\n')]
         )
     )
     config = LLMInferenceConfig(json_mode=True)
     resp = llm.prompt([LLMMessage(content=json_mode_prompt)], config)
-    assert resp == LLMMessage(role="assistant", content="[1, 2, 3, 4, 5]\n")
+
+    assert resp.role == "assistant"
+    assert len(resp.content) == 1
+    content = resp.content[0]
+    assert isinstance(content, TextContent)
+    assert json.loads(content.text) == {"result": [1, 2, 3, 4, 5]}
+
+
+def test_json_mode_no_extra_text() -> None:
+    prompt = dedent("""
+        Generate some fake weather data as a JSON and then write a brief
+        weather report based on it.
+
+        Example JSON output:
+        {
+            "temperature_degC": 7,
+            "humidity_pct": 25,
+            "air_quality_index": 50
+        }
+    """)
+    stub_response = dedent("""
+        "temperature_degC": 7,
+        "humidity_pct": 25,
+        "air_quality_index": 50
+    }""")
+    llm = BedrockNovaLLM(
+        client=make_test_bedrock_runtime_client([nova_response_with_content(stub_response)])
+    )
+    config = LLMInferenceConfig(json_mode=True)
+    resp = llm.prompt([LLMMessage(content=prompt)], config)
+
+    assert resp.role == "assistant"
+    with does_not_raise():
+        _ = json.loads(resp.to_text_only())
 
 
 def encode_image_to_base64_str(image_path: str) -> str:


### PR DESCRIPTION
#31 implemented a solution using stop sequences. A similar solution was already in place for Nova, but not for Converse. This PR makes the prefix and stop sequences consistent across all models.

It allows adds a validation check to `LLMInferenceConfig` to disallow the use of tools with `json_mode=True`. This is because those don't work well together. Using stop sequences ends the response as soon as a stop sequence is encountered, meaning that the LLM cannot follow it up with a tool call.