### PR TITLE
Add Support for Specifying RecordId in Batch Inference Jobs

### DIFF
--- a/src/e84_geoai_common/llm/batch.py
+++ b/src/e84_geoai_common/llm/batch.py
@@ -17,11 +17,11 @@ from e84_geoai_common.util import ensure_bucket_exists
 ValidBatchLLMs = BedrockClaudeLLM | BedrockNovaLLM
 
 
-class PreBatchRecordInput(BaseModel):
+class BatchInputItem(BaseModel):
     """Preliminary input record for batch before applying model."""
 
-    recordId: str | None = None
-    modelInput: list[LLMMessage]
+    record_id: str | None = None
+    model_input: list[LLMMessage]
 
 
 class BatchRecordInput[RequestModel: BaseModel](BaseModel):
@@ -196,7 +196,7 @@ class BedrockBatchInference[RequestModel: BaseModel, ResponseModel: BaseModel]:
         role_arn: str,
         input_s3_file_url: str,
         output_s3_directory_url: str,
-        conversations: list[list[LLMMessage]] | list[PreBatchRecordInput] | None = None,
+        conversations: list[list[LLMMessage]] | list[BatchInputItem] | None = None,
         inference_cfg: LLMInferenceConfig | None = None,
         *,
         create_buckets_if_missing: bool = False,
@@ -277,17 +277,17 @@ class BedrockBatchInference[RequestModel: BaseModel, ResponseModel: BaseModel]:
 
     def _parse_conversations(
         self,
-        conversations: list[list[LLMMessage]] | list[PreBatchRecordInput],
+        conversations: list[list[LLMMessage]] | list[BatchInputItem],
         inference_config: LLMInferenceConfig,
     ) -> list[BatchRecordInput[RequestModel]]:
         input_requests: list[BatchRecordInput[RequestModel]] = []
         for i, conversation in enumerate(conversations):
             record_id = f"RECORD{i:010d}"
 
-            if isinstance(conversation, PreBatchRecordInput):
-                messages = conversation.modelInput
-                if conversation.recordId:
-                    record_id = conversation.recordId
+            if isinstance(conversation, BatchInputItem):
+                messages = conversation.model_input
+                if conversation.record_id:
+                    record_id = conversation.record_id
             else:
                 messages = conversation
 

--- a/src/e84_geoai_common/llm/batch.py
+++ b/src/e84_geoai_common/llm/batch.py
@@ -17,6 +17,13 @@ from e84_geoai_common.util import ensure_bucket_exists
 ValidBatchLLMs = BedrockClaudeLLM | BedrockNovaLLM
 
 
+class PreBatchRecordInput(BaseModel):
+    """Preliminary input record for batch before applying model."""
+
+    recordId: str | None = None
+    modelInput: list[LLMMessage]
+
+
 class BatchRecordInput[RequestModel: BaseModel](BaseModel):
     """Single input record for batch inference."""
 
@@ -189,7 +196,7 @@ class BedrockBatchInference[RequestModel: BaseModel, ResponseModel: BaseModel]:
         role_arn: str,
         input_s3_file_url: str,
         output_s3_directory_url: str,
-        conversations: list[list[LLMMessage]] | None = None,
+        conversations: list[list[LLMMessage]] | list[PreBatchRecordInput] | None = None,
         inference_cfg: LLMInferenceConfig | None = None,
         *,
         create_buckets_if_missing: bool = False,
@@ -236,7 +243,9 @@ class BedrockBatchInference[RequestModel: BaseModel, ResponseModel: BaseModel]:
         self, input_s3_file_url: str, output_s3_directory_url: str
     ) -> tuple[str, str, str]:
         """Return the bucket names and key(s) from an S3 URI."""
-        if not input_s3_file_url.startswith("s3://") or not input_s3_file_url.startswith("s3://"):
+        if not input_s3_file_url.startswith("s3://") or not output_s3_directory_url.startswith(
+            "s3://"
+        ):
             msg = (
                 f"Invalid S3 URI {input_s3_file_url} or {output_s3_directory_url}."
                 f"Must start with 's3://'."
@@ -267,14 +276,25 @@ class BedrockBatchInference[RequestModel: BaseModel, ResponseModel: BaseModel]:
         return input_bucket, input_key, output_bucket
 
     def _parse_conversations(
-        self, conversations: list[list[LLMMessage]], inference_config: LLMInferenceConfig
+        self,
+        conversations: list[list[LLMMessage]] | list[PreBatchRecordInput],
+        inference_config: LLMInferenceConfig,
     ) -> list[BatchRecordInput[RequestModel]]:
         input_requests: list[BatchRecordInput[RequestModel]] = []
         for i, conversation in enumerate(conversations):
-            msg: Any = self.llm.create_request(messages=conversation, config=inference_config)
+            record_id = f"RECORD{i:010d}"
+
+            if isinstance(conversation, PreBatchRecordInput):
+                messages = conversation.modelInput
+                if conversation.recordId:
+                    record_id = conversation.recordId
+            else:
+                messages = conversation
+
+            msg: Any = self.llm.create_request(messages=messages, config=inference_config)
 
             record = BatchRecordInput[self.request_model](
-                recordId=f"RECORD{i:010d}",
+                recordId=record_id,
                 modelInput=self.request_model.model_validate(msg),
             )
             input_requests.append(record)

--- a/src/e84_geoai_common/llm/tests/mock_bedrock.py
+++ b/src/e84_geoai_common/llm/tests/mock_bedrock.py
@@ -30,7 +30,9 @@ BATCH_INPUT_S3 = os.getenv(
 BATCH_OUTPUT_S3 = os.getenv("BATCH_OUTPUT_S3", "s3://example-output-bucket-e84-geoai-common/")
 
 
-def batch_claude_output_example(question: str, content: str, lines: int = 5) -> str:
+def batch_claude_output_example(
+    question: str, content: str, lines: int = 5, record_id_example: str = "RECORD0000000098"
+) -> str:
     """Creates a mock claude batch response with the given text."""
     example_response = {
         "modelInput": {
@@ -40,7 +42,7 @@ def batch_claude_output_example(question: str, content: str, lines: int = 5) -> 
             "temperature": 0.0,
         },
         "modelOutput": claude_response_with_content(content),
-        "recordId": "RECORD0000000098",
+        "recordId": record_id_example,
     }
 
     json_lines: list[str] = []

--- a/tests/llm/test_batch.py
+++ b/tests/llm/test_batch.py
@@ -4,7 +4,7 @@ import pytest
 from moto import mock_aws
 from mypy_boto3_s3 import S3Client
 
-from e84_geoai_common.llm.batch import BedrockBatchInference, PreBatchRecordInput
+from e84_geoai_common.llm.batch import BatchInputItem, BedrockBatchInference
 from e84_geoai_common.llm.core.llm import LLMInferenceConfig, LLMMessage, TextContent
 from e84_geoai_common.llm.models.claude import (
     CLAUDE_3_5_HAIKU,
@@ -52,11 +52,11 @@ def test_claude_create_and_run_job(
     llm_question = "What is 10+10?"
     llm_response = "10 + 10 = 20"
 
-    conversations: list[PreBatchRecordInput] = []
+    conversations: list[BatchInputItem] = []
     for i in range(100):
-        conversation = PreBatchRecordInput(
-            recordId=f"EXAMPLE_RECORD_{i}",
-            modelInput=[
+        conversation = BatchInputItem(
+            record_id=f"EXAMPLE_RECORD_{i}",
+            model_input=[
                 LLMMessage(
                     role="user",
                     content=[TextContent(text=llm_question)],

--- a/tests/llm/test_batch.py
+++ b/tests/llm/test_batch.py
@@ -4,9 +4,7 @@ import pytest
 from moto import mock_aws
 from mypy_boto3_s3 import S3Client
 
-from e84_geoai_common.llm.batch import (
-    BedrockBatchInference,
-)
+from e84_geoai_common.llm.batch import BedrockBatchInference, PreBatchRecordInput
 from e84_geoai_common.llm.core.llm import LLMInferenceConfig, LLMMessage, TextContent
 from e84_geoai_common.llm.models.claude import (
     CLAUDE_3_5_HAIKU,
@@ -54,17 +52,21 @@ def test_claude_create_and_run_job(
     llm_question = "What is 10+10?"
     llm_response = "10 + 10 = 20"
 
-    conversations: list[list[LLMMessage]] = []
-    for _ in range(100):
-        conversation = [
-            LLMMessage(
-                role="user",
-                content=[TextContent(text=llm_question)],
-            )
-        ]
+    conversations: list[PreBatchRecordInput] = []
+    for i in range(100):
+        conversation = PreBatchRecordInput(
+            recordId=f"EXAMPLE_RECORD_{i}",
+            modelInput=[
+                LLMMessage(
+                    role="user",
+                    content=[TextContent(text=llm_question)],
+                )
+            ],
+        )
         conversations.append(conversation)
-
-    batch_response = batch_claude_output_example(llm_question, llm_response)
+    batch_response = batch_claude_output_example(
+        llm_question, llm_response, record_id_example="EXAMPLE_RECORD_1"
+    )
 
     batch = BedrockBatchInference(
         request_model=ClaudeInvokeLLMRequest,
@@ -92,6 +94,7 @@ def test_claude_create_and_run_job(
         assert result.modelOutput is not None
         assert isinstance(result.modelOutput, ClaudeResponse)
         assert result.modelOutput.content[0] == ClaudeTextContent(text=llm_response)
+        assert result.recordId.startswith("EXAMPLE_RECORD_")
 
 
 def test_nova_create_and_run_job(
@@ -143,3 +146,4 @@ def test_nova_create_and_run_job(
         assert result.modelOutput is not None
         assert isinstance(result.modelOutput, NovaResponse)
         assert result.modelOutput.output.message.content[0] == NovaTextContent(text=llm_response)
+        assert result.recordId.startswith("RECORD")  # default value


### PR DESCRIPTION
Right now our batch inference implementation does not support specifying our own record id (we have a default made). This adds support for that, as well as some testing for it.